### PR TITLE
Update cryptroot-ask.sh

### DIFF
--- a/modules.d/90crypt/cryptroot-ask.sh
+++ b/modules.d/90crypt/cryptroot-ask.sh
@@ -176,7 +176,7 @@ fi
 
 if [ $ask_passphrase -ne 0 ]; then
     luks_open="$(command -v cryptsetup) $cryptsetupopts luksOpen"
-    _timeout=$(getargs "rd.luks.timeout")
+    _timeout=$(getarg "rd.luks.timeout")
     _timeout=${_timeout:-0}
     ask_for_password --ply-tries 5 \
         --ply-cmd "$luks_open -T1 $device $luksname" \


### PR DESCRIPTION
use singular argument for timeout value -- plural values create an invalid cryptsetup command line.

This pull request changes...

## Changes

## Checklist
- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #2654